### PR TITLE
Linux: Dont enable bzip2 support in libfreetype

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -157,7 +157,7 @@ pushd "$FREETYPELIB_SOURCE_DIR"
                 CXXFLAGS="$opts" \
                 CPPFLAGS="-I$stage/packages/include/zlib-ng" \
                 LDFLAGS="$plainopts -L$stage/packages/lib/release -Wl,--exclude-libs,libz" \
-                ./configure --with-pic \
+                ./configure --with-pic --without-bzip2 \
                 --prefix="$stage" --libdir="$stage"/lib/release/
             make -j$(nproc)
             make install


### PR DESCRIPTION
As per the other build targets (win, mac), don't enable bzip support in libfreetype. It shouldn't be needed. Not disabling bz2 support results in an extra dependency creeping in for libbz2 which doesn't help things.

The installables for this 3p package are also stale due to the 3p-libpng being broken for linux - I have submitted a PR for  the linux libpng issue and the fix for that is very simple. Once 3p-libpng for linux is fixed, this dependency can be corrected and the package will build and be usable.

Stale dependency in autobuild.xml:
`
              <string>http://automated-builds-secondlife-com.s3.amazonaws.com/ct2/882/1946/libpng-1.6.8.500873-linux64-500873.tar.bz2</string>`
