### PR TITLE
Linux: disable brotli + harfbuzz to prevent extra (and unneeded) depe…

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -157,7 +157,7 @@ pushd "$FREETYPELIB_SOURCE_DIR"
                 CXXFLAGS="$opts" \
                 CPPFLAGS="-I$stage/packages/include/zlib-ng" \
                 LDFLAGS="$plainopts -L$stage/packages/lib/release -Wl,--exclude-libs,libz" \
-                ./configure --with-pic --without-bzip2 \
+                ./configure --with-pic --without-bzip2 --without-brotli --without-harfbuzz \
                 --prefix="$stage" --libdir="$stage"/lib/release/
             make -j$(nproc)
             make install


### PR DESCRIPTION
extra dependency for brotli crept into the resulting library (ldd confirms this):
```
        linux-vdso.so.1 (0x00007ffc1b9b3000)
        libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007fe0c853d000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe0c8314000)
        libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007fe0c82f1000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fe0c864c000)
```
This PR will fix this issue by explicitly disabling brotli (and harfbuzz) support during the library build - the other platforms have this disabled also already - so this will fix the linux64 library.